### PR TITLE
replaced outdated crypto-js links

### DIFF
--- a/TokenAuthMVC.Web/Views/Shared/_Layout.cshtml
+++ b/TokenAuthMVC.Web/Views/Shared/_Layout.cshtml
@@ -7,8 +7,8 @@
 <body>
     @RenderBody()
 
-    <script src="http://crypto-js.googlecode.com/svn/tags/3.0.2/build/rollups/hmac-sha256.js"></script>
-    <script src="http://crypto-js.googlecode.com/svn/tags/3.0.2/build/components/enc-base64-min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/crypto-js/3.1.2/rollups/hmac-sha256.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/crypto-js/3.1.2/components/enc-base64.js"></script>
     <script src="~/Scripts/security.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Crypto-js.googlecode.com is no longer available, but scripts can be downloaded from CDNJS - fixed.
